### PR TITLE
로그인 후 화면 이동 변경

### DIFF
--- a/GuessMe_iOS/Api.swift
+++ b/GuessMe_iOS/Api.swift
@@ -131,7 +131,32 @@ final class Api{
             return Disposables.create {}
         }
     }
-    
+    public func isUserHasQuiz(nickname: String) -> Single<Bool>{
+        let url = baseUrl + "quizzes/\(nickname)"
+                
+        guard let encodedUrl = url.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else{
+            return .create{
+                $0(.error(ApiError.urlEncodingError))
+                return Disposables.create {}
+            }
+        }
+        
+        return .create{single in
+            AF.request(url,method: .get, interceptor: self.interceptor).responseJSON{
+                switch $0.result{
+                case .success(let data):
+                    let json = JSON(data)["_embedded"]
+                    let quizList = json["quizList"].arrayValue
+                    single(.success(!quizList.isEmpty))
+                case .failure(let error):
+                    single(.error(error))
+                }
+            }
+            
+            return Disposables.create {}
+        }
+
+    }
     public func deleteQuiz() -> Completable{
         let url = baseUrl + "quizzes"
                 

--- a/GuessMe_iOS/Login/LoginViewController.swift
+++ b/GuessMe_iOS/Login/LoginViewController.swift
@@ -16,11 +16,36 @@ class LoginViewController: UIViewController{
         super.viewDidLoad()
         setUp()
     }
+    
+    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         setUp()
         viewModel = LoginViewModel()
+        if let _ = UserDefaults.standard.string(forKey: "token"){
+            self.startLoading()
+            self.viewModel.isUserHasQuiz().observeOn(MainScheduler.instance).subscribe(onSuccess: {
+                var vc: UIViewController
+                if $0{//퀴즈를 가지고 있을 때
+                    vc = TabBarController()
+                    
+                }
+                else{
+                    vc = QuizViewController()
+                }
+                vc.modalPresentationStyle = .fullScreen
+                self.present(vc, animated: true){
+                    self.stopLoading()
+                }
+            }, onError: {
+                print($0.localizedDescription)
+                let alert = UIAlertController(title: "로그인", message: "서버 에러", preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: "확인", style: .cancel))
+                self.present(alert, animated: true)
+            }).disposed(by: self.disposeBag)
+        }
     }
+    
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         disposeBag = DisposeBag()
@@ -80,11 +105,26 @@ class LoginViewController: UIViewController{
             }
             self.startLoading()
             self.viewModel.login(id:id, password: password).subscribe(onSuccess: {
-                self.stopLoading()
                 if $0{
-                    let vc = TabBarController()
-                    vc.modalPresentationStyle = .fullScreen
-                    self.present(vc, animated: true)
+                    self.viewModel.isUserHasQuiz().observeOn(MainScheduler.instance).subscribe(onSuccess: {
+                        var vc: UIViewController
+                        if $0{//퀴즈를 가지고 있을 때
+                            vc = TabBarController()
+                            
+                        }
+                        else{
+                            vc = QuizViewController()
+                        }
+                        vc.modalPresentationStyle = .fullScreen
+                        self.present(vc, animated: true){
+                            self.stopLoading()
+                        }
+                    }, onError: {
+                        print($0.localizedDescription)
+                        let alert = UIAlertController(title: "로그인", message: "서버 에러", preferredStyle: .alert)
+                        alert.addAction(UIAlertAction(title: "확인", style: .cancel))
+                        self.present(alert, animated: true)
+                    }).disposed(by: self.disposeBag)
                 }
                 else{
                     let alert = UIAlertController(title: "로그인", message: "아이디 혹은 비밀번호가 맞지 않습니다.", preferredStyle: .alert)

--- a/GuessMe_iOS/Login/LoginViewController.swift
+++ b/GuessMe_iOS/Login/LoginViewController.swift
@@ -16,7 +16,11 @@ class LoginViewController: UIViewController{
         super.viewDidLoad()
         setUp()
     }
-    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        setUp()
+        viewModel = LoginViewModel()
+    }
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         disposeBag = DisposeBag()
@@ -245,7 +249,7 @@ class LoginViewController: UIViewController{
     }
 
     private var disposeBag = DisposeBag()
-    private let viewModel = LoginViewModel()
+    private var viewModel = LoginViewModel()
     
     private weak var loadingView: UIView!
     private weak var loadingIndicator: UIActivityIndicatorView!

--- a/GuessMe_iOS/Login/LoginViewModel.swift
+++ b/GuessMe_iOS/Login/LoginViewModel.swift
@@ -28,4 +28,10 @@ final class LoginViewModel{
             return Disposables.create {}
         }
     }
+    
+    public func isUserHasQuiz() -> Single<Bool>{
+        let nickname = UserDefaults.standard.string(forKey: "nickname")!
+        return Api.shared.isUserHasQuiz(nickname: nickname)
+        
+    }
 }


### PR DESCRIPTION
## 이슈번호

## 작업내용
- 로그아웃을 해 로그인 화면으로 돌아왔을 때 기능이 작동하지 않는 문제 해결
- 로그인 시 유저가 퀴즈가 있다면 메인화면, 없다면 퀴즈 생성 화면으로 이동하도록 변경
- 자동 로그인 추가

## 참고내용

## 스크린샷